### PR TITLE
DAPH-66: changed exception logging to use a string (instead of array)…

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -62,7 +62,7 @@ class Module
                     'Exception: [' . $exception->getMessage() . ']',
                     array(
                         'category' => 'API',
-                        'stackTrace' => $exception->getTrace(),
+                        'stackTrace' => $exception->getTraceAsString(),
                     )
                 );
         });
@@ -84,7 +84,6 @@ class Module
                         'Response: ' . $statusCode . '[' . $e->getResponse() . ']',
                         array(
                             'category' => 'Event',
-                            'stackTrace' => debug_backtrace(),
                         )
                     );
                 }
@@ -95,7 +94,6 @@ class Module
                         'Response: ' . $statusCode . '[' . $e->getResponse() . ']',
                         array(
                             'category' => 'Event',
-                            'stackTrace' => debug_backtrace(),
                         )
                     );
                 }


### PR DESCRIPTION
… for stack trace, removed useless stacktraces elsewhere