### PR TITLE
Sw 878 allow setting error dispatch priority

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -51,6 +51,13 @@ class Module
             function (MvcEvent $event) use ($serviceManager) {
                 if ($event->getParam('exception')) {
                     $exception = $event->getParam('exception');
+
+                    // We don't need to log non-critical server errors
+                    if (method_exists($exception, 'getStatusCode')
+                        && $exception->getStatusCode() < Response::STATUS_CODE_500) {
+                        return;
+                    }
+
                     $serviceManager->get('Logger')->crit(
                         'Exception: [' . $exception->getMessage() . ']',
                         [

--- a/config/sample.logger.global.php
+++ b/config/sample.logger.global.php
@@ -13,6 +13,8 @@ return array(
         'registerExceptionHandler' => false, // exceptions logged to your writers
         // Enable the Symfony error handler provided by CommonUtils
         'symfonyErrorHandler' => false,
+        // Needs to be higher priority than any modules that stop error events propagating
+        'dispatchErrorPriority' => 1,
 
         // multiple zend writer output & zend priority filters
         'writers' => array(


### PR DESCRIPTION
This is to prevent a conflict with the zf api problem package which hooks into the same event at priority 100 and stops it propagating further down, which disabled our error logging.

The second part of this fix is in `opg-sirius` config to set the priority to 101:
https://github.com/ministryofjustice/opg-sirius/pull/1781